### PR TITLE
Add roofline microbenchmarks to measure the GPU ridge point

### DIFF
--- a/vulkan/tests/CMakeLists.txt
+++ b/vulkan/tests/CMakeLists.txt
@@ -5,13 +5,14 @@ add_vulkan_shader_target(vulkan_shaders
     OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/shaders)
 
                                 
-file(GLOB test_src "ComputeSum/*.cpp" 
+file(GLOB test_src "ComputeSum/*.cpp"
                    "ComputeGaussianBlur/*.cpp"
+                   "Roofline/*.cpp"
                     "*.cpp")
 
 add_executable(vulkan_tests ${test_src})
 
-target_include_directories(vulkan_tests PUBLIC ComputeSum ComputeGaussianBlur
+target_include_directories(vulkan_tests PUBLIC ComputeSum ComputeGaussianBlur Roofline
                                     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/shaders)
 
 add_dependencies(vulkan_tests vulkan_shaders)

--- a/vulkan/tests/Roofline/ComputeCopy.comp
+++ b/vulkan/tests/Roofline/ComputeCopy.comp
@@ -1,0 +1,20 @@
+#version 450
+
+layout(binding = 0) uniform UniformBufferObject {
+    int count;  // number of vec4 elements
+}
+ubo;
+
+layout(std430, binding = 1) readonly buffer src_in { vec4 src[]; };
+layout(std430, binding = 2) writeonly buffer dst_out { vec4 dst[]; };
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+// Pure-streaming workload for measuring peak memory bandwidth: coalesced
+// 16-byte loads/stores over buffers far larger than the GPU's caches, with
+// no arithmetic in between.
+void main() {
+    const uint gid = gl_GlobalInvocationID.x;
+    if (gid >= uint(ubo.count)) return;
+    dst[gid] = src[gid];
+}

--- a/vulkan/tests/Roofline/ComputeCopy.cpp
+++ b/vulkan/tests/Roofline/ComputeCopy.cpp
@@ -1,0 +1,52 @@
+#include "ComputeCopy.h"
+
+namespace core {
+namespace vulkan {
+
+ComputeCopy::ComputeCopy(VulkanContext* context, VulkanBuffer& src, VulkanBuffer& dst,
+                         const int count)
+    : VulkanCompute(context),
+      src_buffer_(src),
+      dst_buffer_(dst),
+      uniform_buffer_(context, sizeof(UniformData), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT),
+      uniform_data_{.count = count} {}
+
+void ComputeCopy::Init() {
+  VulkanCompute::Init();
+
+  CreateUniformBufferDescriptorSet(0, uniform_buffer_);
+  CreateStorageBufferDescriptorSet(1, src_buffer_);
+  CreateStorageBufferDescriptorSet(2, dst_buffer_);
+
+  vkUpdateDescriptorSets(context_->logical_device, writes_.size(), writes_.data(), 0, nullptr);
+}
+
+void ComputeCopy::Run(const VkCommandBuffer command_buffer) {
+  uniform_buffer_.MapData(
+      [this](void* data) { memcpy(data, &uniform_data_, sizeof(UniformData)); });
+
+  vkCmdBindPipeline(command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+  vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1,
+                          &descriptor_set_, 0, nullptr);
+
+  const uint32_t group_count =
+      (static_cast<uint32_t>(uniform_data_.count) + kLocalSizeX - 1) / kLocalSizeX;
+  vkCmdDispatch(command_buffer, group_count, 1, 1);
+}
+
+std::vector<BindingInfo> ComputeCopy::GetBindingInfo() const {
+  return {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_COMPUTE_BIT},
+          {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_SHADER_STAGE_COMPUTE_BIT},
+          {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_SHADER_STAGE_COMPUTE_BIT}};
+}
+
+const std::vector<uint32_t>& ComputeCopy::LoadShaderCode() const {
+  static const std::vector<uint32_t> shader_code =
+#include "ComputeCopy.comp.spv"
+      ;
+  return shader_code;
+}
+
+}  // namespace vulkan
+}  // namespace core

--- a/vulkan/tests/Roofline/ComputeCopy.h
+++ b/vulkan/tests/Roofline/ComputeCopy.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "VulkanBuffer.h"
+#include "VulkanCompute.h"
+
+namespace core {
+namespace vulkan {
+
+// Pure-streaming microbenchmark: coalesced vec4 copies between two large
+// storage buffers with no arithmetic. Used to measure the GPU's peak memory
+// bandwidth for the roofline model.
+class ComputeCopy : public VulkanCompute {
+ public:
+  // Must match the shader's local_size_x.
+  static constexpr uint32_t kLocalSizeX = 256;
+
+  // count is the number of vec4 (16-byte) elements to copy.
+  ComputeCopy(VulkanContext* context, VulkanBuffer& src, VulkanBuffer& dst, const int count);
+
+  void Init() override;
+  void Run(const VkCommandBuffer command_buffer);
+
+ protected:
+  std::vector<BindingInfo> GetBindingInfo() const override;
+  const std::vector<uint32_t>& LoadShaderCode() const override;
+
+ private:
+  VulkanBuffer& src_buffer_;
+  VulkanBuffer& dst_buffer_;
+  VulkanBuffer uniform_buffer_;
+  struct UniformData {
+    int count;
+  } uniform_data_;
+};
+
+}  // namespace vulkan
+}  // namespace core

--- a/vulkan/tests/Roofline/ComputeFma.comp
+++ b/vulkan/tests/Roofline/ComputeFma.comp
@@ -1,0 +1,74 @@
+#version 450
+
+layout(binding = 0) uniform UniformBufferObject {
+    int iterations;
+}
+ubo;
+
+layout(std430, binding = 1) writeonly buffer dst_out { float dst[]; };
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+// Pure-ALU workload for measuring peak compute throughput: eight independent
+// FMA chains keep the pipeline full while each chain stays serially dependent
+// across iterations, and no memory is touched inside the loop.
+void main() {
+    const uint gid = gl_GlobalInvocationID.x;
+
+    // Per-thread seeds prevent constant folding.
+    float a0 = float(gid & 63u) * 1e-3 + 0.10;
+    float a1 = a0 + 0.11;
+    float a2 = a0 + 0.12;
+    float a3 = a0 + 0.13;
+    float a4 = a0 + 0.14;
+    float a5 = a0 + 0.15;
+    float a6 = a0 + 0.16;
+    float a7 = a0 + 0.17;
+    // Chains converge toward c / (1 - b) = 0.1, so values stay finite and
+    // never hit denormals or infinities regardless of iteration count.
+    const float b = 0.999999;
+    const float c = 1e-7;
+
+    // 4x unrolled: 32 FMAs (64 FLOP) per iteration. Must match
+    // ComputeFma::kFlopPerIteration on the C++ side.
+    for (int i = 0; i < ubo.iterations; ++i) {
+        a0 = fma(a0, b, c);
+        a1 = fma(a1, b, c);
+        a2 = fma(a2, b, c);
+        a3 = fma(a3, b, c);
+        a4 = fma(a4, b, c);
+        a5 = fma(a5, b, c);
+        a6 = fma(a6, b, c);
+        a7 = fma(a7, b, c);
+
+        a0 = fma(a0, b, c);
+        a1 = fma(a1, b, c);
+        a2 = fma(a2, b, c);
+        a3 = fma(a3, b, c);
+        a4 = fma(a4, b, c);
+        a5 = fma(a5, b, c);
+        a6 = fma(a6, b, c);
+        a7 = fma(a7, b, c);
+
+        a0 = fma(a0, b, c);
+        a1 = fma(a1, b, c);
+        a2 = fma(a2, b, c);
+        a3 = fma(a3, b, c);
+        a4 = fma(a4, b, c);
+        a5 = fma(a5, b, c);
+        a6 = fma(a6, b, c);
+        a7 = fma(a7, b, c);
+
+        a0 = fma(a0, b, c);
+        a1 = fma(a1, b, c);
+        a2 = fma(a2, b, c);
+        a3 = fma(a3, b, c);
+        a4 = fma(a4, b, c);
+        a5 = fma(a5, b, c);
+        a6 = fma(a6, b, c);
+        a7 = fma(a7, b, c);
+    }
+
+    // Publish the result so the compiler cannot eliminate the loop.
+    dst[gid] = a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7;
+}

--- a/vulkan/tests/Roofline/ComputeFma.cpp
+++ b/vulkan/tests/Roofline/ComputeFma.cpp
@@ -1,0 +1,47 @@
+#include "ComputeFma.h"
+
+namespace core {
+namespace vulkan {
+
+ComputeFma::ComputeFma(VulkanContext* context, VulkanBuffer& dst, const int iterations,
+                       const uint32_t group_count)
+    : VulkanCompute(context),
+      dst_buffer_(dst),
+      uniform_buffer_(context, sizeof(UniformData), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT),
+      uniform_data_{.iterations = iterations},
+      group_count_(group_count) {}
+
+void ComputeFma::Init() {
+  VulkanCompute::Init();
+
+  CreateUniformBufferDescriptorSet(0, uniform_buffer_);
+  CreateStorageBufferDescriptorSet(1, dst_buffer_);
+
+  vkUpdateDescriptorSets(context_->logical_device, writes_.size(), writes_.data(), 0, nullptr);
+}
+
+void ComputeFma::Run(const VkCommandBuffer command_buffer) {
+  uniform_buffer_.MapData(
+      [this](void* data) { memcpy(data, &uniform_data_, sizeof(UniformData)); });
+
+  vkCmdBindPipeline(command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+  vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1,
+                          &descriptor_set_, 0, nullptr);
+  vkCmdDispatch(command_buffer, group_count_, 1, 1);
+}
+
+std::vector<BindingInfo> ComputeFma::GetBindingInfo() const {
+  return {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_COMPUTE_BIT},
+          {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_SHADER_STAGE_COMPUTE_BIT}};
+}
+
+const std::vector<uint32_t>& ComputeFma::LoadShaderCode() const {
+  static const std::vector<uint32_t> shader_code =
+#include "ComputeFma.comp.spv"
+      ;
+  return shader_code;
+}
+
+}  // namespace vulkan
+}  // namespace core

--- a/vulkan/tests/Roofline/ComputeFma.h
+++ b/vulkan/tests/Roofline/ComputeFma.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "VulkanBuffer.h"
+#include "VulkanCompute.h"
+
+namespace core {
+namespace vulkan {
+
+// Pure-ALU microbenchmark: every thread runs long register-resident FMA
+// chains with no memory traffic inside the loop. Used to measure the GPU's
+// peak compute throughput for the roofline model.
+class ComputeFma : public VulkanCompute {
+ public:
+  // Must match the shader's local_size_x.
+  static constexpr uint32_t kLocalSizeX = 256;
+  // 32 fused multiply-adds (64 FLOP) per loop iteration per thread; must
+  // match the unrolled loop body in ComputeFma.comp.
+  static constexpr uint64_t kFlopPerIteration = 64;
+
+  ComputeFma(VulkanContext* context, VulkanBuffer& dst, const int iterations,
+             const uint32_t group_count);
+
+  void Init() override;
+  void Run(const VkCommandBuffer command_buffer);
+
+ protected:
+  std::vector<BindingInfo> GetBindingInfo() const override;
+  const std::vector<uint32_t>& LoadShaderCode() const override;
+
+ private:
+  VulkanBuffer& dst_buffer_;
+  VulkanBuffer uniform_buffer_;
+  struct UniformData {
+    int iterations;
+  } uniform_data_;
+  uint32_t group_count_;
+};
+
+}  // namespace vulkan
+}  // namespace core

--- a/vulkan/tests/RooflineTest.cpp
+++ b/vulkan/tests/RooflineTest.cpp
@@ -1,0 +1,157 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <functional>
+#include <memory>
+
+#include "ComputeCopy.h"
+#include "ComputeFma.h"
+#include "VulkanBuffer.h"
+#include "VulkanCommandBuffer.h"
+#include "VulkanContext.h"
+#include "VulkanQueryPool.h"
+#include "VulkanSync.h"
+#include "VulkanUtils.h"
+
+namespace core {
+namespace test {
+namespace {
+
+// Records `record` into a fresh command buffer bracketed by GPU timestamps,
+// submits it, waits for completion, and returns the GPU time in milliseconds.
+double TimeDispatchMs(core::vulkan::VulkanContext& context,
+                      core::vulkan::VulkanCommandBuffer& command_buffer,
+                      core::vulkan::VulkanFence& fence, core::vulkan::VulkanQueryPool& query_pool,
+                      const std::function<void(VkCommandBuffer)>& record) {
+  fence.Reset();
+  vkResetCommandBuffer(command_buffer.buffer(), 0);
+  VkCommandBufferBeginInfo begin_info{};
+  begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+  vkBeginCommandBuffer(command_buffer.buffer(), &begin_info);
+
+  query_pool.Reset(command_buffer.buffer());
+  query_pool.Query(command_buffer.buffer(), 0, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+  record(command_buffer.buffer());
+  query_pool.Query(command_buffer.buffer(), 1, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+
+  VkSubmitInfo submit_info{};
+  command_buffer.Submit(fence.fence, submit_info);
+  vkWaitForFences(context.logical_device, 1, &fence.fence, VK_TRUE, UINT64_MAX);
+
+  query_pool.GetQueryResults();
+  const auto timestamps = query_pool.GetTimeStamps();
+  return (timestamps[1] - timestamps[0]) * (context.timestamp_period / 1000000.0);
+}
+
+}  // namespace
+
+// Measures the two roofline-model ceilings with microbenchmarks and derives
+// the ridge point (peak compute throughput / peak memory bandwidth). Kernels
+// with arithmetic intensity below the ridge point are memory-bound, above it
+// compute-bound.
+TEST(Roofline, RidgePoint) {
+  core::vulkan::QueueFamilyType queue_family_type = core::vulkan::QueueFamilyType::Compute;
+  core::vulkan::VulkanContext context(true, queue_family_type, nullptr);
+  context.Init();
+  core::vulkan::VulkanCommandBuffer command_buffer(&context);
+  core::vulkan::VulkanFence fence(&context);
+  core::vulkan::VulkanQueryPool query_pool(&context, VK_QUERY_TYPE_TIMESTAMP);
+
+  // Early runs also serve as warm-up while DVFS ramps the GPU clock up; the
+  // minimum over all runs is the peak.
+  constexpr int kRuns = 6;
+
+  // ---- Peak compute throughput: register-resident FMA chains ----
+  constexpr uint32_t kFmaGroups = 2048;
+  constexpr uint32_t kFmaThreads = kFmaGroups * core::vulkan::ComputeFma::kLocalSizeX;
+  constexpr int kFmaIterations = 1024;
+
+  core::vulkan::VulkanBuffer fma_dst(
+      &context, kFmaThreads * sizeof(float), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+  auto fma =
+      std::make_unique<core::vulkan::ComputeFma>(&context, fma_dst, kFmaIterations, kFmaGroups);
+  fma->Init();
+
+  double fma_ms = std::numeric_limits<double>::max();
+  for (int run = 0; run < kRuns; ++run) {
+    fma_ms = std::min(fma_ms, TimeDispatchMs(context, command_buffer, fence, query_pool,
+                                             [&](VkCommandBuffer cmd) { fma->Run(cmd); }));
+  }
+
+  const double total_flop = static_cast<double>(kFmaThreads) * kFmaIterations *
+                            core::vulkan::ComputeFma::kFlopPerIteration;
+  const double peak_gflops = total_flop / (fma_ms * 1e6);
+
+  // The chains converge toward 0.1; a finite result proves the loop ran.
+  float fma_sample = 0.0f;
+  fma_dst.MapData([&fma_sample](void* data) { memcpy(&fma_sample, data, sizeof(float)); });
+  EXPECT_TRUE(std::isfinite(fma_sample));
+
+  // ---- Peak memory bandwidth: streaming vec4 copy ----
+  // 8M vec4 = 128 MiB per buffer, far larger than the GPU's caches.
+  constexpr int kCopyCount = 8 * 1024 * 1024;
+  constexpr VkDeviceSize kCopyBytes = static_cast<VkDeviceSize>(kCopyCount) * 16;
+
+  core::vulkan::VulkanBuffer copy_src(
+      &context, kCopyBytes, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+  core::vulkan::VulkanBuffer copy_dst(
+      &context, kCopyBytes, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+  core::vulkan::VulkanBuffer staging(
+      &context, kCopyBytes, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+  staging.MapData([](void* data) {
+    float* floats = static_cast<float*>(data);
+    for (int i = 0; i < kCopyCount * 4; ++i) {
+      floats[i] = static_cast<float>(i % 1024);
+    }
+  });
+  staging.CopyToBuffer(copy_src);
+
+  auto copy = std::make_unique<core::vulkan::ComputeCopy>(&context, copy_src, copy_dst, kCopyCount);
+  copy->Init();
+
+  double copy_ms = std::numeric_limits<double>::max();
+  for (int run = 0; run < kRuns; ++run) {
+    copy_ms = std::min(copy_ms, TimeDispatchMs(context, command_buffer, fence, query_pool,
+                                               [&](VkCommandBuffer cmd) { copy->Run(cmd); }));
+  }
+
+  const double bytes_moved = 2.0 * static_cast<double>(kCopyBytes);  // read + write
+  const double peak_gbps = bytes_moved / (copy_ms * 1e6);
+
+  // Verify the copy actually happened before trusting the bandwidth number.
+  copy_dst.CopyToBuffer(staging);
+  float first = -1.0f, middle = -1.0f, last = -1.0f;
+  staging.MapData([&first, &middle, &last](void* data) {
+    const float* floats = static_cast<const float*>(data);
+    constexpr int kFloatCount = kCopyCount * 4;
+    first = floats[0];
+    middle = floats[kFloatCount / 2];
+    last = floats[kFloatCount - 1];
+  });
+  EXPECT_FLOAT_EQ(first, 0.0f);
+  EXPECT_FLOAT_EQ(middle, static_cast<float>((kCopyCount * 4 / 2) % 1024));
+  EXPECT_FLOAT_EQ(last, static_cast<float>((kCopyCount * 4 - 1) % 1024));
+
+  // ---- Ridge point ----
+  const double ridge_point = peak_gflops / peak_gbps;  // FLOP per byte
+
+  printf("Peak compute throughput: %.1f GFLOP/s (fp32, best of %d runs, %.3f ms)\n", peak_gflops,
+         kRuns, fma_ms);
+  printf("Peak memory bandwidth  : %.1f GB/s (best of %d runs, %.3f ms)\n", peak_gbps, kRuns,
+         copy_ms);
+  printf("Ridge point            : %.1f FLOP/byte\n", ridge_point);
+
+  EXPECT_GT(peak_gflops, 0.0);
+  EXPECT_GT(peak_gbps, 0.0);
+}
+
+}  // namespace test
+}  // namespace core


### PR DESCRIPTION
## What

Adds two compute-shader microbenchmarks under `vulkan/tests/Roofline/` plus a `RooflineTest` that measures this GPU's **ridge point** for the roofline model — the arithmetic intensity (FLOP/byte) at which a kernel flips between memory-bound and compute-bound.

- **`ComputeFma`** — peak compute throughput. A pure-ALU kernel: each thread runs eight independent, register-resident FMA chains (4× unrolled → 32 FMA / 64 FLOP per loop iteration) so the pipeline stays saturated with **zero memory traffic**. The accumulated result is written back once so the compiler can't eliminate the loop.
- **`ComputeCopy`** — peak memory bandwidth. A pure-streaming kernel: coalesced `vec4` (16-byte) loads/stores over **128 MiB device-local buffers** (far larger than the GPU's caches) with no arithmetic, so it measures real DRAM bandwidth (counted read + write).

`ridge_point = peak_GFLOPs / peak_GBps`. Kernels below it are memory-bound; above it, compute-bound.

## Why

To classify whether a given Vulkan shader is compute- or memory-bound, you need the GPU's ridge point, and that requires the two peak ceilings. Vulkan exposes neither FLOP/s nor bandwidth, and vendor spec sheets overstate what real shaders reach — so these measure both empirically instead.

## How it's measured (reviewer notes)

- **GPU timestamp queries** (`VulkanQueryPool`), not CPU wall clock, so submit/sync overhead is excluded.
- Each benchmark runs several times and takes the **best (min) time**; the early runs double as DVFS warm-up.
- Each result is **validated before its timing is trusted**: the FMA output is checked finite (proves the loop ran), and the copy is read back and sampled at head/middle/tail (proves the bandwidth number reflects a real transfer).
- Follows the existing `ComputeSum`/`ComputeGaussianBlur` structure (`VulkanCompute` subclass + `.comp` shader auto-compiled by the existing `vulkan_shaders` target); wired in via the `Roofline/*.cpp` glob in `vulkan/tests/CMakeLists.txt`.

## Results (Apple M2)

```
Peak compute throughput: ~3200 GFLOP/s (fp32)
Peak memory bandwidth  : ~87 GB/s
Ridge point            : ~37 FLOP/byte
```

~87–89% of the theoretical spec ceilings (3.6 TFLOPS / 100 GB/s), a healthy sanity check. `Roofline.RidgePoint` runs in well under a second and passes as part of `vulkan_tests`.

## Notes

- This measures the standard **fp32-FMA × DRAM** roofline. Analyzing cache-resident or fp16 kernels would need additional ceilings (per-precision compute, per-cache-level bandwidth), each with its own ridge point — out of scope here.
- A pre-existing, unrelated working-tree change to `vulkan/src/VulkanCommandBuffer.cpp` (a cosmetic reordering of the move ctor/assignment) was **left out** of this PR to keep it scoped to the roofline work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
